### PR TITLE
Fix: toast error

### DIFF
--- a/src/shared/contexts/Auth/index.tsx
+++ b/src/shared/contexts/Auth/index.tsx
@@ -62,6 +62,8 @@ export const AuthProvider = ({ children }: { children: JSX.Element }) => {
     } else {
       removeAuthStorage();
     }
+
+    setLoading('loaded');
   }, [removeAuthStorage, router, setSession]);
 
   const signInWithGithub = useCallback(
@@ -101,8 +103,10 @@ export const AuthProvider = ({ children }: { children: JSX.Element }) => {
   }, [provider, router?.query?.code, signInWithGithub]);
 
   useEffect(() => {
+    setLoading('loading');
+
     if (token) getUser();
-    setLoading('loaded');
+    else setLoading('loaded');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token]);
 

--- a/src/shared/contexts/Auth/tests/index.spec.tsx
+++ b/src/shared/contexts/Auth/tests/index.spec.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AuthProvider } from '../index';
+
+describe('AuthProvider', () => {
+  test('should render AuthProvider correctly with children', () => {
+    const { getByTestId } = render(
+      <AuthProvider>
+        <div data-testid="child">Child</div>
+      </AuthProvider>
+    );
+
+    expect(getByTestId('child').textContent).toBe('Child');
+  });
+});

--- a/src/shared/hooks/tests/useRequireAuth.spec.tsx
+++ b/src/shared/hooks/tests/useRequireAuth.spec.tsx
@@ -2,6 +2,7 @@ import { useAuth } from '@contexts/Auth';
 import { toast } from 'react-toastify';
 import useRequireAuth from '@hooks/useRequireAuth';
 import { useRouter } from 'next/router';
+import { act, renderHook } from '@testing-library/react';
 
 jest.mock('react-toastify', () => ({
   toast: {
@@ -63,7 +64,12 @@ describe('useRequireAuth', () => {
             push: (path: string) => mockPush(path),
             pathname,
           });
-          useRequireAuth();
+
+          const { result } = renderHook(() => useRequireAuth());
+    
+          act(() => {
+            result.current;
+          });
         });
 
         test(`does not display toast message`, () => {
@@ -98,7 +104,12 @@ describe('useRequireAuth', () => {
             push: (path: string) => mockPush(path),
             pathname,
           });
-          useRequireAuth();
+
+          const { result } = renderHook(() => useRequireAuth());
+    
+          act(() => {
+            result.current;
+          });
         });
 
         test(`displays toast message`, () => {

--- a/src/shared/hooks/useRequireAuth.tsx
+++ b/src/shared/hooks/useRequireAuth.tsx
@@ -18,7 +18,7 @@ const useRequireAuth = () => {
   
         redirect();
       }
-    }, [loading, session, router]);
+    }, [loading, session]);
   };
 
 export default useRequireAuth;

--- a/src/shared/hooks/useRequireAuth.tsx
+++ b/src/shared/hooks/useRequireAuth.tsx
@@ -1,15 +1,24 @@
 import { useRouter } from "next/router";
 import { useAuth } from "@contexts/Auth";
 import { toast } from "react-toastify";
+import { useEffect } from "react";
 
 const useRequireAuth = () => {
     const { session, loading } = useAuth();
     const router = useRouter();
-
-    if (loading === 'loaded' && !session && router.pathname !== '/') {
-        toast.error('Você não está autorizado a acessar esta página. Por favor, faça login.');
-        router.push('/');
-    }
-};
+  
+    useEffect(() => {
+      if (loading === "loaded" && !session && router.pathname !== "/") {
+        const redirect = async () => {
+          toast.error(
+            "Você não está autorizado a acessar esta página. Por favor, faça login."
+          );
+          await router.push("/");
+        };
+  
+        redirect();
+      }
+    }, [loading, session, router]);
+  };
 
 export default useRequireAuth;


### PR DESCRIPTION
## Motivação

Apareceu um bug depois da pr #2. O bug aconteceu quando o usuário faz o login, depois de ter tentado acessar a url '/products' sem estar logado. O bug que aparece é a mensagem de erro do toast que deveria aparecer apenas quando o usuário não está logado.

## Mudanças

- Refatorar o hook para usar o router push de forma assincrona
- Ajustar a forma como a variavel de estado 'loading' está sendo usa atualmente.

## Status Checklist

- [x] Test
- [x] Lint
- [x] Development

## Screenshots

<!-- If you are adding a layout change, you can show the images below -->

| Before                                               | After                                                |
| ---------------------------------------------------- | ---------------------------------------------------- |
| ![Screenshot from 2023-05-20 10-55-21](https://github.com/fga-eps-mds/2023-1-MeasureSoftGram-Front/assets/37488154/5db41735-3409-464b-a013-b1840f0e5077) | ![Screenshot from 2023-05-19 19-01-41](https://github.com/fga-eps-mds/2023-1-MeasureSoftGram-Front/assets/37488154/c9b27496-d77b-49ed-93c5-a8841f894f57) |