### PR TITLE
Hotfix/ Remove scroll da tela Home

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -109,7 +109,7 @@ const Home: NextPageWithLayout = () => {
               <ListNavCard navListData={navListData} />
             </Box>
 
-            <Box display="flex" flex="1" minWidth="78%" flexDirection="column" maxHeight="78vh" gap="2rem" sx={{
+            <Box display="flex" flex="1" minWidth="78%" flexDirection="column" maxHeight="74.7vh" gap="2rem" sx={{
               overflowY: "auto",
               scrollbarWidth: "thin",
               paddingRight: ".5rem",


### PR DESCRIPTION
## Motivação

Atualmente no site quando na tela home existe um scroll geral vertical desnecessário.

![image](https://github.com/fga-eps-mds/2023-1-MeasureSoftGram-Front/assets/71738659/da8bc36f-2023-416a-b0c8-6f973cfd0a9a)

