### PR TITLE
fix: Fix repository filter

### DIFF
--- a/src/pages/products/[product]/components/RepositoriesList/RepositoriesTable/RepositoriesTable.tsx
+++ b/src/pages/products/[product]/components/RepositoriesList/RepositoriesTable/RepositoriesTable.tsx
@@ -26,9 +26,9 @@ const RepositoriesTable: React.FC<Props> = ({ maxCount }: Props) => {
     void router.push(path);
   };
 
-  const handleRepositoriesFilter = (name: string) => {
+  function handleRepositoriesFilter(name: string) {
     if ((name == null || name === '') && repositoryList?.length) {
-      setFilteredRepositories(maxCount ? repositoryList.slice(0, maxCount) : repositoryList);
+      setFilteredRepositories([...repositoryList]);
       return;
     }
     const repositoriesWithName =
@@ -36,14 +36,14 @@ const RepositoriesTable: React.FC<Props> = ({ maxCount }: Props) => {
         currentRepository.name.toLowerCase().includes(name.toLowerCase())
       ) ?? [];
 
-    setFilteredRepositories(maxCount ? repositoriesWithName.slice(0, maxCount) : repositoriesWithName);
-  };
+    setFilteredRepositories([...repositoriesWithName]);
+  }
 
   // update historicalCharacteristics if repositoryList changes
   useEffect(() => {
     if (repositoryList?.length) {
       setFilteredRepositories((prevState) => {
-        const tempRepositoryList = maxCount != null ? [...repositoryList.splice(0, maxCount)] : [...repositoryList];
+        const tempRepositoryList = [...repositoryList];
         const prevString = JSON.stringify(prevState);
         const currentString = JSON.stringify(tempRepositoryList);
 
@@ -72,7 +72,7 @@ const RepositoriesTable: React.FC<Props> = ({ maxCount }: Props) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {filteredRepositories?.map((repo) => (
+          {filteredRepositories?.slice(0, maxCount ?? filteredRepositories.length).map((repo) => (
             <React.Fragment key={repo.id}>
               <TableRow hover style={{ cursor: 'pointer' }} data-testid="repository-row">
                 <TableCell colSpan={2} onClick={() => handleClickRedirects(`${repo.id}-${repo.name}`)}>


### PR DESCRIPTION
## Motivação

O objetivo era corrigir o filtro na listagem de repositórios.

## Mudanças

Foi observado que o slice com o maxCount que estavam sendo feitos anteriormente, estavam causando falha.

- O slice foi movido para o map da lista de repositórios filtrados.

## Status Checklist

<!-- In the status section, you can mark what you have already done -->

- [X] Test
- [X] Lint
- [X] Development

## Screenshots

<!-- If you are adding a layout change, you can show the images below -->

| Before                                               | After                                                |
| ---------------------------------------------------- | ---------------------------------------------------- |
| <img src="https://i.ibb.co/kDg2Zf0/Captura-de-tela-de-2023-06-27-21-09-50.png" alt="Captura-de-tela-de-2023-06-27-21-09-50" border="0"> | <img src="https://i.ibb.co/sPcMC5B/Captura-de-tela-de-2023-06-27-21-17-30.png" alt="Captura-de-tela-de-2023-06-27-21-17-30" border="0">

## Execução

<!-- How do we test the implementation? -->

- Acesse a visão geral do produto e faça o filtro dos repositórios.
