### PR TITLE
feat: get balanceMatrix from api

### DIFF
--- a/src/modules/createRelease/components/Equalizer/hook/tests/useEqualizer.spec.tsx
+++ b/src/modules/createRelease/components/Equalizer/hook/tests/useEqualizer.spec.tsx
@@ -1,0 +1,192 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import useEqualizer from "../useEqualizer";
+
+jest.mock("@services/balanceMatrix", () => ({
+  balanceMatrixService: {
+    getBalanceMatrix: () =>
+      Promise.resolve({
+        data: {
+          result: {
+            reliability: {
+              "+": ["maintainability"],
+              "-": [],
+            },
+            maintainability: {
+              "+": ["reliability"],
+              "-": ["performance_efficiency"],
+            },
+            performance_efficiency: {
+              "+": [],
+              "-": ["maintainability"],
+            },
+          },
+        },
+      }),
+  },
+}));
+
+describe('useEqualizer', () => {
+  it('deve carregar as características', async () => {
+    const { result } = renderHook(() => useEqualizer(['reliability', 'maintainability', "performance_efficiency"]));
+    await waitFor(() => {
+      result.current.getBalanceMatrix()
+      expect(result.current.characteristics).toEqual([
+        {
+          id: 0,
+          key: 'reliability',
+          value: 50,
+          correlations: {
+            '+': ['maintainability'],
+            '-': []
+          }
+        },
+        {
+          id: 1,
+          key: 'maintainability',
+          value: 50,
+          correlations: {
+            '+': ['reliability'],
+            '-': ['performance_efficiency']
+          }
+        },
+        {
+          id: 2,
+          key: 'performance_efficiency',
+          value: 50,
+          correlations: {
+            '+': [],
+            '-': ['maintainability']
+          }
+        }
+      ])
+    })
+  });
+
+  it('deve chamar o addDeltaToChanges', async () => {
+    const { result } = renderHook(() => useEqualizer(['reliability', 'maintainability']));
+    await waitFor(() => {
+      result.current.getBalanceMatrix()
+      result.current.addDeltaToChanges('reliability', 80)
+      expect(result.current.changes).toEqual([{ characteristic_key: 'reliability', delta: 30 }])
+    })
+  })
+
+  it('deve chamar o equalize com e sem allowDynamicBalance', async () => {
+    const { result } = renderHook(() => useEqualizer(['reliability', 'maintainability', 'performance_efficiency']))
+    await waitFor(() => {
+      result.current.getBalanceMatrix()
+      result.current.equalize('maintainability', 80, true)
+      expect(result.current.characteristics).toEqual([
+        {
+          id: 0,
+          key: 'reliability',
+          value: 50,
+          correlations: {
+            '+': ['maintainability'],
+            '-': []
+          }
+        },
+        {
+          id: 1,
+          key: 'maintainability',
+          value: 80,
+          correlations: {
+            '+': ['reliability'],
+            '-': ['performance_efficiency']
+          }
+        },
+        {
+          id: 2,
+          key: 'performance_efficiency',
+          value: 50,
+          correlations: {
+            '+': [],
+            '-': ['maintainability']
+          }
+        }
+      ])
+    })
+
+    await waitFor(() => {
+      result.current.equalize('maintainability', 20, false)
+      expect(result.current.characteristics).toEqual([
+        {
+          id: 0,
+          key: 'reliability',
+          value: 0,
+          correlations: {
+            '+': ['maintainability'],
+            '-': []
+          }
+        },
+        {
+          id: 1,
+          key: 'maintainability',
+          value: 20,
+          correlations: {
+            '+': ['reliability'],
+            '-': ['performance_efficiency']
+          }
+        },
+        {
+          id: 2,
+          key: 'performance_efficiency',
+          value: 100,
+          correlations: {
+            '+': [],
+            '-': ['maintainability']
+          }
+        }
+      ])
+      result.current.equalize('maintainability', 50, false)
+      expect(result.current.characteristics).toEqual([
+        {
+          id: 0,
+          key: 'reliability',
+          value: 30,
+          correlations: {
+            '+': ['maintainability'],
+            '-': []
+          }
+        },
+        {
+          id: 1,
+          key: 'maintainability',
+          value: 50,
+          correlations: {
+            '+': ['reliability'],
+            '-': ['performance_efficiency']
+          }
+        },
+        {
+          id: 2,
+          key: 'performance_efficiency',
+          value: 70,
+          correlations: {
+            '+': [],
+            '-': ['maintainability']
+          }
+        }
+      ])
+    })
+  });
+
+  it('deve chamar o equalize sem correlações na array de características', async () => {
+    const { result } = renderHook(() => useEqualizer(['maintainability']))
+    await waitFor(() => {
+      result.current.getBalanceMatrix()
+      result.current.equalize('maintainability', 80, false)
+      expect(result.current.characteristics).toEqual([
+        {
+          id: 0,
+          key: 'maintainability',
+          value: 80,
+          correlations: {
+            '+': ['reliability'],
+            '-': ['performance_efficiency']
+          }
+        }
+      ])
+    })
+  });
+})

--- a/src/modules/createRelease/components/Equalizer/tests/Equalizer.spec.tsx
+++ b/src/modules/createRelease/components/Equalizer/tests/Equalizer.spec.tsx
@@ -8,8 +8,53 @@ import Equalizer from '../Equalizer';
 jest.mock('@modules/createRelease/context/useCreateRelease', () => ({
   useCreateReleaseContext: () => ({
     preConfigCharacteristics: ['usability', 'maintainability'],
-    handleChangeForm: () => {}
+    handleChangeForm: () => { }
   })
+}));
+
+jest.mock('@modules/createRelease/components/Equalizer/hook/useEqualizer', () => (() => ({
+  characteristics: [
+    {
+      id: 1,
+      key: 'reliability',
+      value: 50,
+      correlations: {
+        '+': ['maintainability'],
+        '-': []
+      }
+    },
+    {
+      id: 2,
+      key: 'maintainability',
+      value: 50,
+      correlations: {
+        '+': ['reliability'],
+        '-': []
+      }
+    }
+  ],
+  equalize: jest.fn(),
+  addDeltaToChanges: jest.fn(),
+  changes: []
+})));
+
+jest.mock('@services/balanceMatrix', () => ({
+  balanceMatrixService: {
+    getBalanceMatrix: () => (Promise.resolve({
+      data: {
+        result: {
+          reliability: {
+            '+': ['maintainability'],
+            '-': []
+          },
+          maintainability: {
+            '+': ['reliability'],
+            '-': []
+          }
+        }
+      }
+    }))
+  }
 }));
 
 jest.mock('@mui/material', () => ({
@@ -39,7 +84,7 @@ describe('<Equalizer />', () => {
   const renderEqualizer = (allowDynamicBalance: boolean = false) =>
     render(
       <Equalizer
-        selectedCharacteristics={['usability', 'compatibility', 'security']}
+        selectedCharacteristics={['reliability', 'maintainability']}
         allowDynamicBalance={allowDynamicBalance}
       />
     );
@@ -52,7 +97,7 @@ describe('<Equalizer />', () => {
   });
 
   describe('Comportamento', () => {
-    it('Deve chamar onChange ao movimnetar o slider permitindo balanceamento dinâmico', () => {
+    it('Deve chamar onChange ao movimnetar o slider permitindo balanceamento dinâmico', async () => {
       const { getAllByTestId } = renderEqualizer(true);
 
       const sliders = getAllByTestId('single-slider');
@@ -64,7 +109,7 @@ describe('<Equalizer />', () => {
       expect(sliders.length).toBe(2);
       expect(labels.length).toBe(2);
     });
-    it('Deve chamar onChange ao movimnetar o slider sem permitir balanceamento dinâmico', () => {
+    it('Deve chamar onChange ao movimnetar o slider sem permitir balanceamento dinâmico', async () => {
       const { getAllByTestId } = renderEqualizer();
 
       const sliders = getAllByTestId('single-slider');

--- a/src/pages/products/Products.tsx
+++ b/src/pages/products/Products.tsx
@@ -111,7 +111,7 @@ const Products: NextPageWithLayout = () => {
               </Box>
 
               <Box display="flex" flexWrap="wrap" marginTop="60px" justifyContent="space-around">
-                {filteredProducts?.map((product, index) => (
+                {filteredProducts?.map((product) => (
                   <Box key={product.id} display="flex" flexDirection="row" paddingRight="20px" paddingBottom="20px">
                     <CardNavigation
                       key={product.id}

--- a/src/pages/products/[product]/repositories/hooks/useQuery.ts
+++ b/src/pages/products/[product]/repositories/hooks/useQuery.ts
@@ -38,6 +38,7 @@ export const useQuery = () => {
         await loadRepositories(organizationId, productId);
       }
     };
+    // eslint-disable-next-line no-console
     fetchData().catch((error) => console.error(error));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query?.product]);

--- a/src/shared/services/balanceMatrix.ts
+++ b/src/shared/services/balanceMatrix.ts
@@ -1,0 +1,11 @@
+/* eslint-disable class-methods-use-this */
+import api from './api';
+
+class BalanceMatrixService {
+  getBalanceMatrix() {
+    return api.get(`balance-matrix`);
+  }
+}
+
+export const balanceMatrixService = new BalanceMatrixService();
+Object.freeze(balanceMatrixService);

--- a/src/shared/services/index.ts
+++ b/src/shared/services/index.ts
@@ -1,2 +1,3 @@
 export { default } from './api';
 export { productQuery } from './product';
+export { balanceMatrixService } from './balanceMatrix';

--- a/src/shared/services/tests/balanceMatrix.spec.ts
+++ b/src/shared/services/tests/balanceMatrix.spec.ts
@@ -1,0 +1,11 @@
+import { balanceMatrixService } from '..';
+import api from '../api';
+
+jest.mock('../api');
+
+describe('BalanceMatrix', () => {
+  it('should call api.get with the right URL', async () => {
+    await balanceMatrixService.getBalanceMatrix();
+    expect(api.get).toHaveBeenCalledWith('balance-matrix');
+  });
+});

--- a/src/shared/utils/getCharacteristicsWithBalanceMatrix.ts
+++ b/src/shared/utils/getCharacteristicsWithBalanceMatrix.ts
@@ -1,49 +1,26 @@
 import { CharacteristicWithBalanceMatrix } from '@customTypes/product';
 
-const BALANCE_MATRIX = {
-  functional_suitability: {
-    '+': ['usability', 'reliability', 'maintainability'],
-    '-': ['performance_efficiency', 'security']
-  },
-  performance_efficiency: {
-    '+': [],
-    '-': ['functional_suitability', 'usability', 'compatibility', 'security', 'maintainability', 'portability']
-  },
-  usability: {
-    '+': ['functional_suitability', 'reliability'],
-    '-': ['performance_efficiency']
-  },
-  compatibility: {
-    '+': ['portability'],
-    '-': ['security']
-  },
-  reliability: {
-    '+': ['functional_suitability', 'usability', 'maintainability'],
-    '-': []
-  },
-  security: {
-    '+': ['reliability'],
-    '-': ['performance_efficiency', 'usability', 'compatibility']
-  },
-  maintainability: {
-    '+': ['functional_suitability', 'compatibility', 'reliability', 'portability'],
-    '-': ['performance_efficiency']
-  },
-  portability: {
-    '+': ['compatibility', 'maintainability'],
-    '-': ['performance_efficiency']
-  }
+type BalanceMatrixRow = {
+  '+': string[];
+  '-': string[];
 };
 
-const getCharacteristicsWithBalanceMatrix = (characteristics: string[]): CharacteristicWithBalanceMatrix[] =>
+type BalanceMatrix = {
+  [key: string]: BalanceMatrixRow;
+};
+
+const getCharacteristicsWithBalanceMatrix = (
+  characteristics: string[],
+  balanceMatrix: BalanceMatrix
+): CharacteristicWithBalanceMatrix[] =>
   characteristics.reduce(
-    (acc, item, index) => [
+    (acc: CharacteristicWithBalanceMatrix[], item: string, index: number): CharacteristicWithBalanceMatrix[] => [
       ...acc,
       {
         key: item,
         id: index,
         value: 50,
-        correlations: BALANCE_MATRIX[item as keyof typeof BALANCE_MATRIX]
+        correlations: balanceMatrix[item as keyof typeof balanceMatrix]
       }
     ],
     []


### PR DESCRIPTION
## Motivação

Deixar de usar a matriz de balanceamento hardcoded no frontend e buscar através da rota da service

## Mudanças

- Foi adicionada uma rota para consultar a matriz de balanceamento
- A função de associar as características com o balanceamento foi alterada para receber a matriz como parâmetro

## Status Checklist

<!-- In the status section, you can mark what you have already done -->

- [ ] Test
- [ ] Lint
- [ ] Development

## Execução

- Faça o planejamento da releas,e o comportamento do balanceamento das metas deve manter o anterior
