### PR TITLE
feat: Página de release com paginação e filtros

### DIFF
--- a/src/pages/products/[product]/components/ReleasesList/ReleasesList.tsx
+++ b/src/pages/products/[product]/components/ReleasesList/ReleasesList.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 
-import { Box, Typography, Container } from '@mui/material';
+import { Box, Typography, Container, Button } from '@mui/material';
 
 import { productQuery } from '@services/product';
 import { useProductContext } from '@contexts/ProductProvider';
 import { useOrganizationContext } from '@contexts/OrganizationProvider';
 import { useRequest } from '@hooks/useRequest';
 import { CompareGoalAccomplished } from '@customTypes/product';
-import RepositoriesTable from './ReleasesTable';
+import { useRouter } from 'next/router';
+import ReleasesTable from './ReleasesTable';
 
 import * as Styles from './styles';
 import Skeleton from './Skeleton';
@@ -15,20 +16,32 @@ import Skeleton from './Skeleton';
 function ReleasesList() {
   const { currentProduct } = useProductContext();
   const { currentOrganization } = useOrganizationContext();
+  const router = useRouter();
 
   const { data: releaseList, isLoading } = useRequest<CompareGoalAccomplished[]>(
-    productQuery.getReleaseList(currentOrganization?.id, currentProduct?.id as string)
+    productQuery.getReleaseList(currentOrganization?.id as string, currentProduct?.id as string)
   );
   if (isLoading) return <Skeleton />;
+
+  function pushToReleasesPath() {
+    const releasesPath = `/products/${currentOrganization?.id}-${currentProduct?.id}-${currentProduct?.name}/releases`;
+    void router.push(releasesPath);
+  }
+
   return (
     <Box display="flex" flexDirection="column" mt="42px">
       <Styles.Wrapper>
         <Container>
           <Typography variant="h5" marginRight="10px" mb="32px" color="#538BA3" fontWeight="500">
-            Releases
+            Última Release criada
           </Typography>
 
-          <RepositoriesTable releaseList={releaseList} />
+          <ReleasesTable releaseList={releaseList?.slice(0, 1) ?? []} />
+          <Box display="flex" flexDirection="column" mt="10px" alignItems="center">
+            <Button onClick={() => pushToReleasesPath()} variant="text">
+              VER MAIS...
+            </Button>
+          </Box>
         </Container>
       </Styles.Wrapper>
     </Box>

--- a/src/pages/products/[product]/components/ReleasesList/ReleasesTable/ReleasesTable.tsx
+++ b/src/pages/products/[product]/components/ReleasesList/ReleasesTable/ReleasesTable.tsx
@@ -18,7 +18,7 @@ function ReleasesTable({ releaseList }: ReleasesTableProps) {
   const router = useRouter();
 
   const handleClickCell = (path: string) => {
-    void router.push(`${currentOrganization?.id}-${currentProduct?.id}-${currentProduct?.name}/${path}`);
+    void router.push(`/products/${currentOrganization?.id}-${currentProduct?.id}-${currentProduct?.name}/releases/${path}`);
   };
 
   return (
@@ -29,7 +29,6 @@ function ReleasesTable({ releaseList }: ReleasesTableProps) {
             <TableCell>Nome</TableCell>
             <TableCell>Início da release</TableCell>
             <TableCell>Fim da release</TableCell>
-            <TableCell />
           </TableRow>
         </TableHead>
         <TableBody>
@@ -37,14 +36,13 @@ function ReleasesTable({ releaseList }: ReleasesTableProps) {
             <TableRow
               key={release.id}
               hover
-              onClick={() => void handleClickCell(`releases/${release?.id}`)}
+              onClick={() => handleClickCell(`${release?.id}`)}
               style={{ cursor: 'pointer' }}
               data-testid="repository-row"
             >
               <TableCell>{release?.release_name}</TableCell>
               <TableCell>{formatDate(release?.start_at)}</TableCell>
               <TableCell>{formatDate(release?.end_at)}</TableCell>
-              <TableCell />
             </TableRow>
           ))}
         </TableBody>

--- a/src/pages/products/[product]/components/ReleasesList/ReleasesTable/tests/ReleasesTable.spec.tsx
+++ b/src/pages/products/[product]/components/ReleasesList/ReleasesTable/tests/ReleasesTable.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { OrganizationProvider } from '@contexts/OrganizationProvider';
 import { ProductProvider } from '@contexts/ProductProvider';
+import { useRouter } from 'next/router';
 import ReleasesTable from '../ReleasesTable';
 
 jest.mock('next/router', () => ({
@@ -9,6 +10,8 @@ jest.mock('next/router', () => ({
     push: jest.fn()
   })
 }));
+
+const FIRST_RELEASE_NAME = 'First release';
 
 describe('ReleasesTable component', () => {
   afterEach(() => {
@@ -19,7 +22,7 @@ describe('ReleasesTable component', () => {
     const releaseList = [
       {
         id: '1',
-        release_name: 'First release',
+        release_name: FIRST_RELEASE_NAME,
         start_at: '2022-01-01T10:00:00Z',
         end_at: '2022-01-05T10:00:00Z',
         goal: {}
@@ -35,8 +38,32 @@ describe('ReleasesTable component', () => {
     );
 
     const firstRow = getByTestId('repository-row').firstChild;
-    expect(firstRow.textContent).toBe('First release');
+    expect(firstRow.textContent).toBe(FIRST_RELEASE_NAME);
     expect(firstRow.nextSibling?.textContent).toBe('01 de janeiro de 2022');
     expect(firstRow.nextSibling?.nextSibling?.textContent).toBe('05 de janeiro de 2022');
+  });
+
+  it('should redirect to release page when click on a release row', () => {
+    const releaseList = [
+      {
+        id: '1',
+        release_name: FIRST_RELEASE_NAME,
+        start_at: '2022-01-01T10:00:00Z',
+        end_at: '2022-01-05T10:00:00Z',
+        goal: {}
+      }
+    ];
+
+    const { getByTestId } = render(
+      <OrganizationProvider>
+        <ProductProvider>
+          <ReleasesTable releaseList={releaseList} />
+        </ProductProvider>
+      </OrganizationProvider>
+    );
+
+    const firstRow = getByTestId('repository-row').firstChild;
+    fireEvent.click(firstRow);
+    expect(useRouter().push).toHaveBeenCalled() as jest.Mocked<any>;
   });
 });

--- a/src/pages/products/[product]/components/ReleasesList/tests/ReleasList.spec.tsx
+++ b/src/pages/products/[product]/components/ReleasesList/tests/ReleasList.spec.tsx
@@ -1,14 +1,22 @@
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { useRequest } from '@hooks/useRequest';
+import { useRouter } from 'next/router';
 import ReleasesList from '../ReleasesList';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    push: jest.fn()
+  })
+}));
 
 jest.mock('@contexts/ProductProvider', () => ({
   useProductContext: jest.fn(() => ({
     currentProduct: {
-      id: '1'
+      id: '1',
+      name: 'MeasureSoftGram'
     }
   }))
 }));
@@ -51,5 +59,32 @@ describe('<ReleasesList />', () => {
     expect(queryByText('Nome')).toBeInTheDocument();
     expect(queryByText('Início da release')).toBeInTheDocument();
     expect(queryByText('Fim da release')).toBeInTheDocument();
+  });
+
+  it('renders the skeleton when loading', () => {
+    (useRequest as jest.Mock).mockReturnValueOnce({
+      data: [],
+      isLoading: true
+    });
+
+    const { queryByText } = render(<ReleasesList />);
+    expect(queryByText('Nome')).not.toBeInTheDocument();
+  });
+
+  it('render empty array when data is undefined', () => {
+    (useRequest as jest.Mock).mockReturnValueOnce({
+      data: undefined,
+      isLoading: false
+    });
+
+    const { queryByText } = render(<ReleasesList />);
+    expect(queryByText('Nome')).toBeInTheDocument();
+  });
+
+  it('call pushToReleasesPath when click on button', () => {
+    const { getByRole } = render(<ReleasesList />);
+    const button = getByRole('button', { name: 'VER MAIS...' });
+    fireEvent.click(button);
+    expect(useRouter().push).toBeCalledWith('/products/1-1-MeasureSoftGram/releases')
   });
 });

--- a/src/pages/products/[product]/components/ReleasesList/tests/__snapshots__/ReleasList.spec.tsx.snap
+++ b/src/pages/products/[product]/components/ReleasesList/tests/__snapshots__/ReleasList.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`<ReleasesList /> renders without crashing 1`] = `
         <h5
           class="MuiTypography-root MuiTypography-h5 css-3ta6hh-MuiTypography-root"
         >
-          Releases
+          Última Release criada
         </h5>
         <div
           class="MuiTableContainer-root css-rorn0c-MuiTableContainer-root"
@@ -46,16 +46,26 @@ exports[`<ReleasesList /> renders without crashing 1`] = `
                 >
                   Fim da release
                 </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                  scope="col"
-                />
               </tr>
             </thead>
             <tbody
               class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
             />
           </table>
+        </div>
+        <div
+          class="MuiBox-root css-1aobbod"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            VER MAIS...
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
         </div>
       </div>
     </div>

--- a/src/pages/products/[product]/releases/Releases.tsx
+++ b/src/pages/products/[product]/releases/Releases.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import Head from 'next/head';
 
-import { Box, Container, Pagination, Skeleton, Stack, TextField, Typography } from '@mui/material';
+import { Box, Container, Pagination, Skeleton, Stack, TextField, Typography, Tooltip } from '@mui/material';
 
 import { NextPageWithLayout } from '@pages/_app.next';
 
@@ -49,37 +49,41 @@ const Releases: NextPageWithLayout = () => {
         </Box>
         <Box display="flex" flexDirection="column" padding="20px"
           style={{ backgroundColor: 'white', border: '1px solid #113d4c80', borderRadius: '10px' }}>
-          <Box display="flex" justifyContent="space-evenly">
+          <Box display="flex" justifyContent="space-between" marginBottom='30px'>
             <Box>
               <Typography color="#538BA3">
                 Início da release
               </Typography>
-              <TextField
-                type="date"
-                required
-                value={startDate}
-                onChange={(e) => setStartDate(e.target.value)}
-                inputProps={{
-                  'data-testid': 'inicio-release'
-                }}
-                size='small'
-              />
+              <Tooltip title='Ao selecionar uma data, são apresentadas todas as releases com datas iniciais exatamente iguais e posteriores às da selecionada'>
+                <TextField
+                  type="date"
+                  required
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  inputProps={{
+                    'data-testid': 'inicio-release'
+                  }}
+                  size='small'
+                />
+              </Tooltip>
             </Box>
 
             <Box>
               <Typography color="#538BA3">
                 Fim da release
               </Typography>
-              <TextField
-                type="date"
-                required
-                size='small'
-                value={endDate}
-                onChange={(e) => setEndDate(e.target.value)}
-                inputProps={{
-                  'data-testid': 'fim-release'
-                }}
-              />
+              <Tooltip title='Ao selecionar uma data, são apresentadas todas as releases com datas finais exatamente iguais e anteriores às da selecionada'>
+                <TextField
+                  type="date"
+                  required
+                  size='small'
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  inputProps={{
+                    'data-testid': 'fim-release'
+                  }}
+                />
+              </Tooltip>
             </Box>
             <Box marginTop="16px">
               <SearchButton

--- a/src/pages/products/[product]/releases/Releases.tsx
+++ b/src/pages/products/[product]/releases/Releases.tsx
@@ -1,0 +1,109 @@
+import React, { useMemo, useState } from 'react';
+import Head from 'next/head';
+
+import { Box, Container, Pagination, Skeleton, Stack, TextField, Typography } from '@mui/material';
+
+import { NextPageWithLayout } from '@pages/_app.next';
+
+import getLayout from '@components/Layout';
+
+import { productQuery } from '@services/product';
+import { useProductContext } from '@contexts/ProductProvider';
+import { useOrganizationContext } from '@contexts/OrganizationProvider';
+import { useRequest } from '@hooks/useRequest';
+import { CompareGoalAccomplished } from '@customTypes/product';
+import SearchButton from '@components/SearchButton';
+import ReleasesTable from '../components/ReleasesList/ReleasesTable';
+import filterReleaseList from './util/filterReleaseList';
+
+const RELEASES_PER_PAGE = 10;
+
+const Releases: NextPageWithLayout = () => {
+  const [startDate, setStartDate] = useState<string>('');
+  const [endDate, setEndDate] = useState<string>('');
+  const [name, setName] = useState<string>('');
+  const [page, setPage] = useState<number>(1);
+  const { currentProduct } = useProductContext();
+  const { currentOrganization } = useOrganizationContext();
+  const { data: releaseList, isLoading } = useRequest<CompareGoalAccomplished[]>(
+    productQuery.getReleaseList(currentOrganization?.id as string, currentProduct?.id as string)
+  );
+
+  const filteredReleaseList = useMemo(() => filterReleaseList(releaseList ?? [], name, startDate, endDate), [releaseList, name, startDate, endDate])
+
+  return isLoading ? (<Skeleton />) :
+    <>
+      <Head>
+        <title> Releases </title>
+      </Head>
+
+      <Container>
+        <Box display="flex" flexDirection="column">
+          <Box display="flex" gap="1rem" marginTop="40px" marginBottom="36px">
+            <Box display="flex" alignItems="center">
+              <Typography variant="h4" marginRight="10px" color="#33568E" fontWeight="500">
+                Releases
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+        <Box display="flex" flexDirection="column" padding="20px"
+          style={{ backgroundColor: 'white', border: '1px solid #113d4c80', borderRadius: '10px' }}>
+          <Box display="flex" justifyContent="space-evenly">
+            <Box>
+              <Typography color="#538BA3">
+                Início da release
+              </Typography>
+              <TextField
+                type="date"
+                required
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                inputProps={{
+                  'data-testid': 'inicio-release'
+                }}
+                size='small'
+              />
+            </Box>
+
+            <Box>
+              <Typography color="#538BA3">
+                Fim da release
+              </Typography>
+              <TextField
+                type="date"
+                required
+                size='small'
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                inputProps={{
+                  'data-testid': 'fim-release'
+                }}
+              />
+            </Box>
+            <Box marginTop="16px">
+              <SearchButton
+                label='Buscar releases'
+                placeHolder='Insira o nome da release'
+                onInput={(e) => setName(e.target.value)}
+              />
+            </Box>
+          </Box>
+          <ReleasesTable releaseList={(filteredReleaseList.slice((page - 1) * RELEASES_PER_PAGE, page * RELEASES_PER_PAGE))} />
+          <Stack spacing={2} sx={{ mt: 2 }} justifyContent="center" alignItems="center">
+            <Pagination
+              count={Math.ceil(filteredReleaseList.length / RELEASES_PER_PAGE)}
+              onChange={(e, newPage) => { setPage(newPage) }}
+              color='primary'
+              size='large'
+              shape="rounded"
+            />
+          </Stack>
+        </Box>
+      </Container >
+    </>
+};
+
+Releases.getLayout = getLayout;
+
+export default Releases;

--- a/src/pages/products/[product]/releases/index.page.ts
+++ b/src/pages/products/[product]/releases/index.page.ts
@@ -1,0 +1,1 @@
+export { default } from './Releases';

--- a/src/pages/products/[product]/releases/tests/Releases.spec.tsx
+++ b/src/pages/products/[product]/releases/tests/Releases.spec.tsx
@@ -1,0 +1,101 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import { useRequest } from "@hooks/useRequest";
+import Releases from "../Releases";
+import filterReleaseList from "../util/filterReleaseList";
+
+jest.mock('@contexts/ProductProvider', () => ({
+  useProductContext: jest.fn(() => ({
+    currentProduct: {
+      id: '1',
+      name: 'MeasureSoftGram'
+    }
+  }))
+}));
+
+jest.mock('@contexts/OrganizationProvider', () => ({
+  useOrganizationContext: jest.fn(() => ({
+    currentOrganization: {
+      id: '1'
+    }
+  }))
+}));
+
+jest.mock('@hooks/useRequest', () => ({
+  useRequest: jest.fn(() => ({
+    data: [],
+    isLoading: false
+  }))
+}));
+
+jest.mock('../util/filterReleaseList', () => jest.fn(() => []));
+
+interface MockPaginationProps {
+  // eslint-disable-next-line no-unused-vars
+  onChange: (_event: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+const MockPagination = ({ onChange }: MockPaginationProps) => (
+  <select data-testid="select-page" onChange={onChange}>
+    <option value="1">1</option>
+    <option value="2">2</option>
+  </select>
+)
+
+jest.mock('@mui/material', () => ({
+  ...jest.requireActual('@mui/material'),
+  Pagination: (props: any) => <MockPagination {...props} />
+}));
+
+describe('<Releases />', () => {
+  it('Deve corresponder ao snapshot', async () => {
+    const { asFragment } = render(<Releases />);
+
+    expect(asFragment()).toMatchSnapshot();
+  })
+
+  it('Deve filtrar as releases pelo nome, data de início e data de fim', async () => {
+    const { getByTestId, getByRole } = render(<Releases />);
+
+    const startDate = getByTestId('inicio-release');
+    const endDate = getByTestId('fim-release');
+    const searchButton = getByRole('textbox', { name: /Buscar releases/i });
+
+    await act(async () => {
+      fireEvent.change(startDate, { target: { value: '2021-01-01' } });
+      fireEvent.change(endDate, { target: { value: '2021-01-02' } });
+      fireEvent.input(searchButton, { target: { value: 'MeasureSoftGram' } });
+    });
+
+    expect(filterReleaseList).toHaveBeenCalledWith([], 'MeasureSoftGram', '2021-01-01', '2021-01-02');
+  })
+
+  it('Deve mostrar ao menos uma opção de página', async () => {
+    const { getByTestId } = render(<Releases />);
+
+    const pageSelect = getByTestId('select-page');
+
+    fireEvent.change(pageSelect, { target: { value: '1' } });
+    expect(pageSelect).toBeDefined();
+  })
+
+  it('Deve chamar o filterReleaseList com array vazia quando o releaseList for undefined', async () => {
+    (useRequest as jest.Mock).mockImplementationOnce(() => ({
+      data: undefined,
+      isLoading: false
+    }));
+
+    render(<Releases />);
+
+    expect(filterReleaseList).toHaveBeenCalledWith([], '', '', '');
+  })
+
+  it('Deve mostrar o Skeleton enquanto o isLoading for true', async () => {
+    (useRequest as jest.Mock).mockImplementationOnce(() => ({
+      data: undefined,
+      isLoading: true
+    }));
+
+    const { queryByText } = render(<Releases />);
+    expect(queryByText('Nome')).toBeNull();
+  })
+});

--- a/src/pages/products/[product]/releases/tests/__snapshots__/Releases.spec.tsx.snap
+++ b/src/pages/products/[product]/releases/tests/__snapshots__/Releases.spec.tsx.snap
@@ -1,0 +1,233 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Releases /> Deve corresponder ao snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiContainer-root MuiContainer-maxWidthLg css-1oqqzyl-MuiContainer-root"
+  >
+    <div
+      class="MuiBox-root css-j7qwjs"
+    >
+      <div
+        class="MuiBox-root css-1k2nw5y"
+      >
+        <div
+          class="MuiBox-root css-70qvj9"
+        >
+          <h4
+            class="MuiTypography-root MuiTypography-h4 css-1f3qdbj-MuiTypography-root"
+          >
+            Releases
+          </h4>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-1k9wtw"
+      style="background-color: white; border: 1px solid #113d4c80; border-radius: 10px;"
+    >
+      <div
+        class="MuiBox-root css-102lqhp"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-3lak7q-MuiTypography-root"
+          >
+            Início da release
+          </p>
+          <div
+            class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          >
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
+                data-testid="inicio-release"
+                id=":r0:"
+                required=""
+                type="date"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-ihdtdm"
+                >
+                  <span
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-0"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-3lak7q-MuiTypography-root"
+          >
+            Fim da release
+          </p>
+          <div
+            class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          >
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
+                data-testid="fim-release"
+                id=":r1:"
+                required=""
+                type="date"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-ihdtdm"
+                >
+                  <span
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1yuhvjn"
+        >
+          <button
+            aria-label="search"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-78trlr-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="SearchIcon"
+              focusable="false"
+              style="fill: #113d4c;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+          <div
+            class="MuiFormControl-root MuiTextField-root text css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1pysi21-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for="search-bar"
+              id="search-bar-label"
+            >
+              Buscar releases
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
+                id="search-bar"
+                placeholder="Insira o nome da release"
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-yjsfm1"
+                >
+                  <span>
+                    Buscar releases
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiTableContainer-root css-rorn0c-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-rqglhn-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          >
+            <tr
+              class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
+                scope="col"
+              >
+                Nome
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
+                scope="col"
+              >
+                Início da release
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
+                scope="col"
+              >
+                Fim da release
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+          />
+        </table>
+      </div>
+      <div
+        class="css-1pimw9g-MuiStack-root"
+      >
+        <select
+          data-testid="select-page"
+        >
+          <option
+            value="1"
+          >
+            1
+          </option>
+          <option
+            value="2"
+          >
+            2
+          </option>
+        </select>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/pages/products/[product]/releases/util/filterReleaseList.ts
+++ b/src/pages/products/[product]/releases/util/filterReleaseList.ts
@@ -1,0 +1,19 @@
+import { CompareGoalAccomplished } from '@customTypes/product';
+
+function filterReleaseList(
+  releases: CompareGoalAccomplished[],
+  name: string,
+  startDate: string,
+  endDate: string
+): CompareGoalAccomplished[] {
+  return releases.filter((release) => {
+    const endDateObject = new Date(endDate);
+    endDateObject.setUTCHours(23, 59, 59);
+    const hasName = !name || release.release_name.toLowerCase().includes(name.toLowerCase());
+    const isAfterStartDate = !startDate || new Date(release.start_at) >= new Date(startDate);
+    const isBeforeEndDate = !endDate || new Date(release.end_at) <= endDateObject;
+    return isAfterStartDate && hasName && isBeforeEndDate;
+  });
+}
+
+export default filterReleaseList;

--- a/src/pages/products/[product]/releases/util/tests/filterReleaseList.spec.ts
+++ b/src/pages/products/[product]/releases/util/tests/filterReleaseList.spec.ts
@@ -1,0 +1,28 @@
+import { CompareGoalAccomplished } from '@customTypes/product';
+import filterReleaseList from '../filterReleaseList';
+
+describe('Filter Release List', () => {
+  it('Deve retornar uma lista de releases filtrada por nome e datas', () => {
+    const releases = [
+      {
+        id: 1,
+        release_name: 'Release 1',
+        start_at: '2021-01-01',
+        end_at: '2021-01-02'
+      },
+      {
+        id: 2,
+        release_name: 'Release 2',
+        start_at: '2021-01-03',
+        end_at: '2021-01-04'
+      }
+    ];
+    const filteredReleases = filterReleaseList(
+      releases as unknown as CompareGoalAccomplished[],
+      'Release 1',
+      '2021-01-01',
+      '2021-01-02'
+    );
+    expect(filteredReleases).toEqual([releases[0]]);
+  });
+});

--- a/src/pages/products/[product]/repositories/[repository]/components/Header/Header.tsx
+++ b/src/pages/products/[product]/repositories/[repository]/components/Header/Header.tsx
@@ -12,7 +12,7 @@ function Header() {
         <Typography variant="h4" marginRight="10px">
           Repositório
         </Typography>
-        <Typography variant="h4" fontWeight="300">
+        <Typography variant="h4" fontWeight="500" color="#33568E">
           {currentRepository?.name}
         </Typography>
       </Box>

--- a/src/shared/components/Layout/SideMenu/SideMenu.tsx
+++ b/src/shared/components/Layout/SideMenu/SideMenu.tsx
@@ -3,7 +3,6 @@ import { FiBarChart2, FiGitBranch, FiPaperclip } from 'react-icons/fi';
 import { useAuth } from '@contexts/Auth';
 import { useProductContext } from '@contexts/ProductProvider';
 import { useRouter } from 'next/router';
-import { useRepositoryContext } from '@contexts/RepositoryProvider';
 import { useOrganizationContext } from '@contexts/OrganizationProvider';
 import SideMenuItem from './SideMenuItem/SideMenuItem';
 import SideMenuWrapper from './SideMenuWrapper';
@@ -22,7 +21,6 @@ function SideMenu() {
   const { session } = useAuth();
   const { currentOrganization } = useOrganizationContext();
   const { currentProduct } = useProductContext();
-  const { currentRepository } = useRepositoryContext();
   const router = useRouter();
 
   const MenuItems: SideMenuItemType[] = [
@@ -47,7 +45,7 @@ function SideMenu() {
       text: 'Releases',
       tooltip: 'Releases de cada repositório',
       path: `/products/${currentOrganization?.id}-${currentProduct?.id}-${currentProduct?.name}/releases`,
-      disable: !currentRepository,
+      disable: !currentProduct,
       selected: router.query?.release !== undefined
     }
   ];


### PR DESCRIPTION
## Motivação

Criar uma visualização geral para que o usuário consiga ter acesso a todas as releases planejadas.

## Mudanças

- Criação de uma tela para alocar todas as releases planejadas;
- Criação de filtros para data inicial e final da release;
- Criação de um filtro para busca do nome da release;
- Estruturação de paginação para as releases.

## Status Checklist

- [X] Test
- [X] Lint
- [X] Development

## Screenshots

<img src="https://i.ibb.co/3p5g4NB/Captura-de-tela-de-2023-07-09-22-28-10.png" /> <img src="https://i.ibb.co/xMRhrsW/Captura-de-tela-de-2023-07-09-22-31-15.png" /> <img src="https://i.ibb.co/GH9sFzn/Captura-de-tela-de-2023-07-09-22-31-09.png" /> |

## Execução

- Acessar a visão geral de algum dos produtos;
- Ir em 'Última release criada';
- Depois clicar em 'Ver mais';
- Visualizar a página com as releases listadas;
- Utilizar os filtros de data inicial e final e o de busca por nomes de releases;
- Navegar pelas releases utilizando a paginação.
