### PR TITLE
Fix/release planning

### DIFF
--- a/src/modules/createRelease/components/ConfigsForm/ConfigsForm.tsx
+++ b/src/modules/createRelease/components/ConfigsForm/ConfigsForm.tsx
@@ -48,6 +48,11 @@ const ConfigForm = ({
       value: Measure | Characteristic | Subcharacteristic,
       previousValue?: Characteristic | Subcharacteristic) => {
 
+      if (tabs && !tabs.includes(previousValue?.key || '')) {
+        onChange(iterator[type]({ data, key: value.key, weight: 0 }));
+        return;
+      }
+
       if (checkboxValues.includes(value.key)) {
         const tabName = previousValue?.key;
         if (keyGetter(newLimiters).indexOf(value.key) === -1) {
@@ -61,7 +66,20 @@ const ConfigForm = ({
   }, [type, checkboxValues]);
 
   useEffect(() => {
-    if (tabs) setTabValue(tabs[0]);
+    if (tabs) {
+      setTabValue(tabs[0])
+      const newCheckboxValues = checkboxValues;
+      componentIterator[type](data, (
+        value: Measure | Characteristic | Subcharacteristic,
+        previousValue?: Characteristic | Subcharacteristic) => {
+
+        if (!tabs.includes(previousValue?.key || '') && checkboxValues.includes(value.key)) {
+          newCheckboxValues.splice(newCheckboxValues.indexOf(value.key), 1);
+        }
+
+      })
+      setCheckboxValues(newCheckboxValues);
+    };
   }, [tabs]);
 
   useEffect(() => {

--- a/src/modules/createRelease/components/ConfigsForm/tests/ConfigsForm.spec.tsx
+++ b/src/modules/createRelease/components/ConfigsForm/tests/ConfigsForm.spec.tsx
@@ -105,5 +105,25 @@ describe('<ConfigsForm />', () => {
       fireEvent.click(button);
       expect(setCheckboxValues).toBeCalledTimes(2);
     });
+
+    it('Deve chamar o onChange quando o tab não estiver incluso', () => {
+      const onChange = jest.fn();
+
+      render(
+        <ConfigsForm
+          type="subcharacteristic"
+          setCheckboxValues={jest.fn()}
+          onChange={onChange}
+          setIsValuesValid={jest.fn()}
+          subtitle={SUBTITLE_TEST}
+          checkboxValues={CHECKBOX_VALUES_SUBCHAR}
+          tabs={[CHECKBOX_VALUES_CHAR[1]]}
+          data={DATA}
+          disable={false}
+        />
+      );
+
+      expect(onChange).toBeCalled();
+    });
   });
 });

--- a/src/modules/createRelease/components/Equalizer/hook/useEqualizer.ts
+++ b/src/modules/createRelease/components/Equalizer/hook/useEqualizer.ts
@@ -13,7 +13,6 @@ export default function useEqualizer(selectedCharacteristics: string[], lastGoal
   const getBalanceMatrix = () => {
     balanceMatrixService.getBalanceMatrix().then((response) => {
       setBalanceMatrix(response.data.result);
-      updateCharacteristicsWithBalanceMatrix();
     });
   };
 
@@ -37,8 +36,6 @@ export default function useEqualizer(selectedCharacteristics: string[], lastGoal
       const value = valuesCommitted[characteristicDragged];
 
       const delta = newValue - value;
-
-      console.log('newChanges', [...changes, { characteristic_key: characteristicDragged, delta }]);
 
       setChanges((prevChanges) => [...prevChanges, { characteristic_key: characteristicDragged, delta }]);
 
@@ -90,6 +87,10 @@ export default function useEqualizer(selectedCharacteristics: string[], lastGoal
   useEffect(() => {
     getBalanceMatrix();
   }, []);
+
+  useEffect(() => {
+    updateCharacteristicsWithBalanceMatrix();
+  }, [balanceMatrix]);
 
   const reset = () => {
     updateCharacteristicsWithBalanceMatrix();

--- a/src/modules/createRelease/context/useCreateRelease.tsx
+++ b/src/modules/createRelease/context/useCreateRelease.tsx
@@ -171,7 +171,7 @@ export function CreateReleaseProvider({
     }
     setReleaseInfoForm((form) => ({
       ...form,
-      characteristics: configData.map((c: Characteristic) => c.key)
+      characteristics: configData.filter((c: Characteristic) => c.weight > 0).map((c: Characteristic) => c.key)
     }))
     setCharacteristicData(newConfigData);
   }


### PR DESCRIPTION
## Motivação

Na ultima versão houve alguns bugs no planejamento de releases, sendo eles:
* Quando uma característica era desselecionada, a validação das sub características na etapa posterior  não funcionava e travava o fluxo de planejamentos
* Em alguns momentos o estado da matriz de balanceamento era perdido e isso gerava um erro na hora de mexer nos sliders das metas
* A parte de balanceamento de metas não estava respeitando as características selecionadas (sempre mostrava 2)

## Mudanças

* No ConfigsForm foram adicionadas duas verificações pra quando as tabs não incluir o valor pai de uma subcaracterística ou measure, nessas verificações:
     *  Os checkbox são setados corretamente, pra evitar itens sendo checados quando o item pai não tiver sido checado na etapa anterior
     * Os valores são setados pra 0, pra evitar que os valores de itens não selecionados interfiram no cálculo de validação
 * No equalizer, as características sempre são atualizadas quando a matriz de balanceamento for atualizada, evitando momentos em que ela fica undefined
 * No useCreateRelease, as características selecionadas passaram a ser iguais as que foram selecionadas nos checkbox

## Status Checklist

<!-- In the status section, you can mark what you have already done -->

- [x] Test
- [x] Lint
- [x] Development


## Execução

<!-- How do we test the implementation? -->

- Acesse a página de planejamento de release
- Teste cenários diferentes de criação de release, mudando principalmente as características e subcaracterísticas selecionadas
